### PR TITLE
Refactor: Extract new workspace openssh-sftp-error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["openssh-portable"]
 [workspace]
 members = [
     "sftp-test-common",
+    "openssh-sftp-error",
 ]
 
 [features]
@@ -24,13 +25,11 @@ members = [
 ci-tests = []
 
 [dependencies]
-thiserror = "1.0.29"
-awaitable = "0.3.3"
+openssh-sftp-error = { version = "0.1.0", path = "openssh-sftp-error" }
+
 concurrent_arena = "0.1.6"
 derive_destructure2 = "0.1.0"
 once_cell = { version = "1.9.0", features = ["parking_lot"] }
-
-openssh-sftp-protocol = "0.21.5"
 
 # Since concurrent_arena, awaitable and tokio-io-utility uses
 # dependency parking_lot anyway, enabling feature parking_lot

--- a/openssh-sftp-error/CHANGELOG.md
+++ b/openssh-sftp-error/CHANGELOG.md
@@ -1,0 +1,1 @@
+The changelog for this crate is kept in the project's Rust documentation in the changelog module.

--- a/openssh-sftp-error/Cargo.toml
+++ b/openssh-sftp-error/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "openssh-sftp-error"
+version = "0.1.0"
+edition = "2018"
+
+authors = ["Jiahao XU <Jiahao_XU@outlook.com>"]
+
+license = "MIT"
+description = "Error type used when communicating with openssh sftp server."
+repository = "https://github.com/openssh-rust/openssh-sftp-client"
+
+keywords = ["ssh", "multiplex", "async", "network", "sftp"]
+categories = ["asynchronous", "network-programming", "api-bindings"]
+
+[dependencies]
+thiserror = "1.0.29"
+awaitable = "0.3.3"
+openssh-sftp-protocol = "0.21.5"
+
+tokio = { version = "1.11.0", features = ["rt"] }

--- a/openssh-sftp-error/LICENSE
+++ b/openssh-sftp-error/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Jiahao XU
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/openssh-sftp-error/src/lib.rs
+++ b/openssh-sftp-error/src/lib.rs
@@ -1,13 +1,15 @@
 #![forbid(unsafe_code)]
 
-use super::lowlevel::{SftpErrMsg, SftpErrorKind};
-
 use std::io;
 use std::num::TryFromIntError;
 use std::process::ExitStatus;
 
 use thiserror::Error;
 
+pub use awaitable;
+
+pub use openssh_sftp_protocol;
+pub use openssh_sftp_protocol::response::{ErrMsg as SftpErrMsg, ErrorCode as SftpErrorKind};
 use openssh_sftp_protocol::ssh_format;
 
 /// Error returned by [`crate::lowlevel`] and [`crate::highlevel`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,8 @@
 /// Changelog for this crate.
 pub mod changelog;
 
-mod error;
-pub use error::Error;
+pub use openssh_sftp_error::Error;
+use openssh_sftp_error::{awaitable, openssh_sftp_protocol};
 
 pub mod highlevel;
 pub mod lowlevel;

--- a/src/lowlevel/awaitable_responses.rs
+++ b/src/lowlevel/awaitable_responses.rs
@@ -2,9 +2,9 @@
 
 use super::Error;
 
+use crate::openssh_sftp_protocol::response::ResponseInner;
 use concurrent_arena::Arena;
 use derive_destructure2::destructure;
-use openssh_sftp_protocol::response::ResponseInner;
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -25,7 +25,7 @@ pub(crate) enum Response<Buffer> {
     ExtendedReply(Box<[u8]>),
 }
 
-pub(crate) type Awaitable<Buffer> = awaitable::Awaitable<Buffer, Response<Buffer>>;
+pub(crate) type Awaitable<Buffer> = crate::awaitable::Awaitable<Buffer, Response<Buffer>>;
 
 /// BITARRAY_LEN must be LEN / usize::BITS and LEN must be divisble by usize::BITS.
 const BITARRAY_LEN: usize = 2;

--- a/src/lowlevel/awaitables.rs
+++ b/src/lowlevel/awaitables.rs
@@ -11,11 +11,11 @@ use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use crate::openssh_sftp_protocol::file_attrs::FileAttrs;
+use crate::openssh_sftp_protocol::response::{NameEntry, ResponseInner, StatusCode};
+use crate::openssh_sftp_protocol::ssh_format;
+use crate::openssh_sftp_protocol::HandleOwned;
 use derive_destructure2::destructure;
-use openssh_sftp_protocol::file_attrs::FileAttrs;
-use openssh_sftp_protocol::response::{NameEntry, ResponseInner, StatusCode};
-use openssh_sftp_protocol::ssh_format;
-use openssh_sftp_protocol::HandleOwned;
 
 /// The data returned by [`WriteEnd::send_read_request`].
 #[derive(Debug, Clone)]

--- a/src/lowlevel/connection.rs
+++ b/src/lowlevel/connection.rs
@@ -13,7 +13,7 @@ use std::sync::{
     Arc,
 };
 
-use openssh_sftp_protocol::constants::SSH2_FILEXFER_VERSION;
+use crate::openssh_sftp_protocol::constants::SSH2_FILEXFER_VERSION;
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Notify;

--- a/src/lowlevel/mod.rs
+++ b/src/lowlevel/mod.rs
@@ -48,15 +48,15 @@ pub use awaitable_responses::Id;
 
 pub use buffer::{Buffer, ToBuffer};
 
-pub use openssh_sftp_protocol::file_attrs::{
+pub use super::openssh_sftp_protocol::file_attrs::{
     FileAttrs, FileType, Permissions, UnixTimeStamp, UnixTimeStampError,
 };
-pub use openssh_sftp_protocol::open_options::{CreateFlags, OpenOptions};
-pub use openssh_sftp_protocol::request::OpenFileRequest;
-pub use openssh_sftp_protocol::response::{
+pub use super::openssh_sftp_protocol::open_options::{CreateFlags, OpenOptions};
+pub use super::openssh_sftp_protocol::request::OpenFileRequest;
+pub use super::openssh_sftp_protocol::response::{
     ErrMsg as SftpErrMsg, ErrorCode as SftpErrorKind, Extensions, Limits, NameEntry,
 };
-pub use openssh_sftp_protocol::{Handle, HandleOwned};
+pub use super::openssh_sftp_protocol::{Handle, HandleOwned};
 
 pub use super::Error;
 

--- a/src/lowlevel/read_end.rs
+++ b/src/lowlevel/read_end.rs
@@ -12,10 +12,10 @@ use std::fmt::Debug;
 use std::io;
 use std::pin::Pin;
 
-use openssh_sftp_protocol::constants::SSH2_FILEXFER_VERSION;
-use openssh_sftp_protocol::response::{self, ServerVersion};
-use openssh_sftp_protocol::serde::de::DeserializeOwned;
-use openssh_sftp_protocol::ssh_format::from_bytes;
+use crate::openssh_sftp_protocol::constants::SSH2_FILEXFER_VERSION;
+use crate::openssh_sftp_protocol::response::{self, ServerVersion};
+use crate::openssh_sftp_protocol::serde::de::DeserializeOwned;
+use crate::openssh_sftp_protocol::ssh_format::from_bytes;
 
 use pin_project::pin_project;
 use tokio::io::{copy_buf, sink, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite};

--- a/src/lowlevel/write_end.rs
+++ b/src/lowlevel/write_end.rs
@@ -13,12 +13,12 @@ use std::io::IoSlice;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 
+use crate::openssh_sftp_protocol::file_attrs::FileAttrs;
+use crate::openssh_sftp_protocol::request::*;
+use crate::openssh_sftp_protocol::serde::Serialize;
+use crate::openssh_sftp_protocol::ssh_format::Serializer;
+use crate::openssh_sftp_protocol::Handle;
 use bytes::Bytes;
-use openssh_sftp_protocol::file_attrs::FileAttrs;
-use openssh_sftp_protocol::request::*;
-use openssh_sftp_protocol::serde::Serialize;
-use openssh_sftp_protocol::ssh_format::Serializer;
-use openssh_sftp_protocol::Handle;
 
 use tokio::io::AsyncWrite;
 

--- a/src/lowlevel/writer_buffered.rs
+++ b/src/lowlevel/writer_buffered.rs
@@ -7,8 +7,8 @@ use std::io::{self, IoSlice};
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 
+use crate::openssh_sftp_protocol::ssh_format::SerBacker;
 use bytes::{BufMut, Bytes, BytesMut};
-use openssh_sftp_protocol::ssh_format::SerBacker;
 
 use pin_project::pin_project;
 use tokio::io::{AsyncWrite, AsyncWriteExt};


### PR DESCRIPTION
The `Error` type is shared by both lowleve and highlevel.

This PR extracts into a workspace so that it can be shared by both while they are extracted to be workspace.

The reason why this is put as a separate crate instead of inside `openssh-sftp-client-lowlevel` is that I don't want the highlevel API to expose a type from lowlevel crate, which forces the highlevel crate to release a new major version whenever the lowlevel crate releases a new major version.

Related to #11 

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>