### PR TITLE
Enable user to specify `buffer_size` in lowleve and highlevel API

### DIFF
--- a/openssh-sftp-client-lowlevel/tests/lowlevel.rs
+++ b/openssh-sftp-client-lowlevel/tests/lowlevel.rs
@@ -43,7 +43,10 @@ async fn flush(read_end: &mut ReadEnd) {
 async fn connect_with_extensions() -> (WriteEnd, ReadEnd, process::Child, Extensions) {
     let (child, stdin, stdout) = launch_sftp().await;
 
-    let (write_end, mut read_end) = lowlevel::connect(stdout, Mutex::new(stdin)).await.unwrap();
+    let (write_end, mut read_end) =
+        lowlevel::connect(stdout, NonZeroUsize::new(1000).unwrap(), Mutex::new(stdin))
+            .await
+            .unwrap();
     flush(&mut read_end).await;
     let extensions = read_end.receive_server_hello().await.unwrap();
     (write_end, read_end, child, extensions)

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,9 @@
 #[allow(unused_imports)]
 use crate::*;
 
+/// ## Added
+///  - [`SftpOptions::buffer_size`]
+///
 /// ## Changed
 ///  - All types in `highlevel` now does not have generic parameter `W`
 ///    except for `Sftp::new`

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,9 +1,10 @@
-use std::num::{NonZeroU16, NonZeroU32};
+use std::num::{NonZeroU16, NonZeroU32, NonZeroUsize};
 use std::time::Duration;
 
 /// Options when creating [`super::Sftp`].
 #[derive(Debug, Copy, Clone, Default)]
 pub struct SftpOptions {
+    buffer_size: Option<NonZeroUsize>,
     flush_interval: Option<Duration>,
     max_read_len: Option<NonZeroU32>,
     max_write_len: Option<NonZeroU32>,
@@ -14,6 +15,7 @@ impl SftpOptions {
     /// Create a new [`SftpOptions`].
     pub const fn new() -> Self {
         Self {
+            buffer_size: None,
             flush_interval: None,
             max_read_len: None,
             max_write_len: None,
@@ -95,5 +97,19 @@ impl SftpOptions {
         self.max_pending_requests
             .map(NonZeroU16::get)
             .unwrap_or(100)
+    }
+
+    /// Set the buffer size.
+    ///
+    /// It is set to 100 by default.
+    #[must_use]
+    pub fn buffer_size(mut self, buffer_size: NonZeroUsize) -> Self {
+        self.buffer_size = Some(buffer_size);
+        self
+    }
+
+    pub(super) fn get_buffer_size(&self) -> NonZeroUsize {
+        self.buffer_size
+            .unwrap_or_else(|| NonZeroUsize::new(100).unwrap())
     }
 }

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -36,8 +36,12 @@ impl Sftp {
         stdout: R,
         options: SftpOptions,
     ) -> Result<Self, Error> {
-        let (write_end, read_end) =
-            connect(stdout, Auxiliary::new(options.get_max_pending_requests())).await?;
+        let (write_end, read_end) = connect(
+            stdout,
+            options.get_buffer_size(),
+            Auxiliary::new(options.get_max_pending_requests()),
+        )
+        .await?;
 
         let (rx, read_task) = create_read_task(read_end);
 


### PR DESCRIPTION
Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>