### PR TITLE
Fix confusing API `copy_to`: Make `n` non-zero

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,14 @@
 #[allow(unused_imports)]
 use crate::*;
 
+/// ## Added
+///  - [`file::File::copy_all_to`] to copy until EOF.
+///    This function is extracted from the old `copy_to`
+///    function.
+///
+/// ## Changed
+///  - [`file::File::copy_to`] now takes [`std::num::NonZeroU64`]
+///    instead of `u64`.
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/tests/highlevel.rs
+++ b/tests/highlevel.rs
@@ -5,7 +5,7 @@ use std::convert::identity;
 use std::convert::TryInto;
 use std::fs;
 use std::io::IoSlice;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::path::PathBuf;
 use std::stringify;
 
@@ -551,7 +551,10 @@ async fn sftp_file_copy_to() {
             .unwrap();
 
         file0
-            .copy_to(&mut file1, content.len().try_into().unwrap())
+            .copy_to(
+                &mut file1,
+                NonZeroU64::new(content.len().try_into().unwrap()).unwrap(),
+            )
             .await
             .unwrap();
 


### PR DESCRIPTION
And add a new API `File::copy_all_to`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>