### PR TITLE
Refactor: Rm `TokioCompatFile::max_buffer_len`

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -3,10 +3,12 @@ use crate::*;
 
 /// ## Fixed
 ///  - Changelog of v0.11.0-rc.1
+///
 /// ## Added
 ///  - [`file::File::copy_all_to`] to copy until EOF.
 ///    This function is extracted from the old `copy_to`
 ///    function.
+///  - [`file::TokioCompatFile::capacity`]
 ///
 /// ## Changed
 ///  - [`file::File::copy_to`] now takes [`std::num::NonZeroU64`]

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -10,6 +10,7 @@ use crate::*;
 ///    function.
 ///  - [`file::TokioCompatFile::capacity`]
 ///  - [`file::TokioCompatFile::reserve`]
+///  - [`file::TokioCompatFile::shrink_to`]
 ///
 /// ## Changed
 ///  - [`file::File::copy_to`] now takes [`std::num::NonZeroU64`]

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -9,6 +9,7 @@ use crate::*;
 ///    This function is extracted from the old `copy_to`
 ///    function.
 ///  - [`file::TokioCompatFile::capacity`]
+///  - [`file::TokioCompatFile::reserve`]
 ///
 /// ## Changed
 ///  - [`file::File::copy_to`] now takes [`std::num::NonZeroU64`]

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -15,6 +15,11 @@ use crate::*;
 /// ## Changed
 ///  - [`file::File::copy_to`] now takes [`std::num::NonZeroU64`]
 ///    instead of `u64`.
+///  - [`file::TokioCompatFile::with_capacity`] does not take
+///    `max_buffer_len` anymore.
+///
+/// ## Removed
+///  - `file::DEFAULT_MAX_BUFLEN`
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -19,7 +19,7 @@ use tokio::io::AsyncSeek;
 use tokio_io_utility::IoSliceExt;
 
 mod tokio_compat_file;
-pub use tokio_compat_file::{TokioCompatFile, DEFAULT_BUFLEN, DEFAULT_MAX_BUFLEN};
+pub use tokio_compat_file::{TokioCompatFile, DEFAULT_BUFLEN};
 
 mod utility;
 use utility::{take_bytes, take_io_slices};

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -140,6 +140,9 @@ impl<'s> TokioCompatFile<'s> {
     }
 
     /// Return capacity of the internal buffer
+    ///
+    /// Note that if there are pending requests, then the actual
+    /// capacity might be more than the returned value.
     pub fn capacity(&self) -> usize {
         self.buffer.capacity()
     }
@@ -151,6 +154,16 @@ impl<'s> TokioCompatFile<'s> {
 
         if curr_cap < new_cap {
             self.buffer.reserve(new_cap - curr_cap);
+        }
+    }
+
+    /// Shrink the capacity of the internal buffer to at most `cap`
+    /// bytes.
+    pub fn shrink_to(&mut self, new_cap: usize) {
+        let curr_cap = self.capacity();
+
+        if curr_cap > new_cap {
+            self.buffer = BytesMut::with_capacity(new_cap);
         }
     }
 

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -144,6 +144,16 @@ impl<'s> TokioCompatFile<'s> {
         self.buffer.capacity()
     }
 
+    /// Reserve the capacity of the internal buffer for at least `cap`
+    /// bytes.
+    pub fn reserve(&mut self, new_cap: usize) {
+        let curr_cap = self.capacity();
+
+        if curr_cap < new_cap {
+            self.buffer.reserve(new_cap - curr_cap);
+        }
+    }
+
     /// This function is a low-level call.
     ///
     /// It needs to be paired with the `consume` method or

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -23,10 +23,6 @@ use derive_destructure2::destructure;
 /// The default length of the buffer used in [`TokioCompatFile`].
 pub const DEFAULT_BUFLEN: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(4096) };
 
-/// The default maximum length of the buffer that can be created in
-/// [`AsyncRead`] implementation of [`TokioCompatFile`].
-pub const DEFAULT_MAX_BUFLEN: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(4096 * 10) };
-
 fn sftp_to_io_error(sftp_err: Error) -> io::Error {
     match sftp_err {
         Error::IOError(io_error) => io_error,
@@ -62,7 +58,6 @@ pub struct TokioCompatFile<'s> {
     inner: File<'s>,
 
     buffer_len: NonZeroUsize,
-    max_buffer_len: NonZeroUsize,
     buffer: BytesMut,
 
     read_future: Option<AwaitableDataFuture<Buffer>>,
@@ -73,35 +68,21 @@ pub struct TokioCompatFile<'s> {
 }
 
 impl<'s> TokioCompatFile<'s> {
-    /// Create a [`TokioCompatFile`] using [`DEFAULT_BUFLEN`] and
-    /// [`DEFAULT_MAX_BUFLEN`].
+    /// Create a [`TokioCompatFile`] using [`DEFAULT_BUFLEN`].
     pub fn new(inner: File<'s>) -> Self {
-        Self::with_capacity(inner, DEFAULT_BUFLEN, DEFAULT_MAX_BUFLEN)
+        Self::with_capacity(inner, DEFAULT_BUFLEN)
     }
 
     /// Create a [`TokioCompatFile`].
     ///
     /// * `buffer_len` - buffer len to be used in [`AsyncBufRead`]
     ///   and the minimum length to read in [`AsyncRead`].
-    /// * `max_buffer_len` - maximum len to be used in [`AsyncRead`].
-    ///
-    /// If `max_buffer_len` is less than `buffer_len`, then it will be set to
-    /// `buffer_len`.
-    pub fn with_capacity(
-        inner: File<'s>,
-        buffer_len: NonZeroUsize,
-        mut max_buffer_len: NonZeroUsize,
-    ) -> Self {
-        if max_buffer_len < buffer_len {
-            max_buffer_len = buffer_len;
-        }
-
+    pub fn with_capacity(inner: File<'s>, buffer_len: NonZeroUsize) -> Self {
         Self {
             inner,
 
             buffer: BytesMut::new(),
             buffer_len,
-            max_buffer_len,
 
             read_future: None,
             read_cancellation_future: BoxedWaitForCancellationFuture::new(),
@@ -348,7 +329,7 @@ impl<'s> From<TokioCompatFile<'s>> for File<'s> {
 /// Reads, writes, and seeks can be performed independently.
 impl Clone for TokioCompatFile<'_> {
     fn clone(&self) -> Self {
-        Self::with_capacity(self.inner.clone(), self.buffer_len, self.max_buffer_len)
+        Self::with_capacity(self.inner.clone(), self.buffer_len)
     }
 }
 
@@ -436,7 +417,6 @@ impl AsyncRead for TokioCompatFile<'_> {
 
         if self.buffer.is_empty() {
             let n = max(remaining, DEFAULT_BUFLEN.get());
-            let n = min(n, self.max_buffer_len.get());
             let n = n.try_into().unwrap_or(u32::MAX);
             let n = NonZeroU32::new(n).unwrap();
 

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -139,6 +139,11 @@ impl<'s> TokioCompatFile<'s> {
         self.into_inner().close().await
     }
 
+    /// Return capacity of the internal buffer
+    pub fn capacity(&self) -> usize {
+        self.buffer.capacity()
+    }
+
     /// This function is a low-level call.
     ///
     /// It needs to be paired with the `consume` method or


### PR DESCRIPTION
to simplify `TokioCompatFile` implementation and makes `TokioCompatFile::with_capacity` less confusing.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>