### PR TITLE
Rename `SftpOptions::{write, read}_end_buffer_size` and improve their documentations

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -5,6 +5,9 @@ use crate::*;
 ///  - Rename `SftpOptions::write_end_buffer_size` to
 ///    [`SftpOptions::requests_buffer_size`] and improve its
 ///    documentation.
+///  - Rename `SftpOptions::read_end_buffer_size` to
+///    [`SftpOptions::responses_buffer_size`] and improve its
+///    documentation.
 #[doc(hidden)]
 pub mod unreleased {}
 
@@ -31,7 +34,7 @@ pub mod v_0_11_0_rc_2 {}
 
 /// ## Added
 ///  - `SftpOptions::write_end_buffer_size`
-///  - [`SftpOptions::read_end_buffer_size`]
+///  - `SftpOptions::read_end_buffer_size`
 ///
 /// ## Changed
 ///  - All types now does not have generic parameter `W`

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -2,7 +2,9 @@
 use crate::*;
 
 /// ## Changed
-///  - Improve documentation for [`SftpOptions::write_end_buffer_size`]
+///  - Rename `SftpOptions::write_end_buffer_size` to
+///    [`SftpOptions::requests_buffer_size`] and improve its
+///    documentation.
 #[doc(hidden)]
 pub mod unreleased {}
 
@@ -28,7 +30,7 @@ pub mod unreleased {}
 pub mod v_0_11_0_rc_2 {}
 
 /// ## Added
-///  - [`SftpOptions::write_end_buffer_size`]
+///  - `SftpOptions::write_end_buffer_size`
 ///  - [`SftpOptions::read_end_buffer_size`]
 ///
 /// ## Changed

--- a/src/options.rs
+++ b/src/options.rs
@@ -107,7 +107,7 @@ impl SftpOptions {
     ///
     /// It is set to 100 by default.
     #[must_use]
-    pub const fn write_end_buffer_size(mut self, buffer_size: NonZeroUsize) -> Self {
+    pub const fn requests_buffer_size(mut self, buffer_size: NonZeroUsize) -> Self {
         self.write_end_buffer_size = Some(buffer_size);
         self
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -123,7 +123,7 @@ impl SftpOptions {
     ///
     /// It is set to 1024 by default.
     #[must_use]
-    pub const fn read_end_buffer_size(mut self, buffer_size: NonZeroUsize) -> Self {
+    pub const fn responses_buffer_size(mut self, buffer_size: NonZeroUsize) -> Self {
         self.read_end_buffer_size = Some(buffer_size);
         self
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -101,7 +101,7 @@ impl SftpOptions {
             .unwrap_or(100)
     }
 
-    /// Set the init buffer size for write_end.
+    /// Set the init buffer size for requests.
     /// It is used to store [`bytes::Bytes`] and it will be resized
     /// to fit the pending requests.
     ///
@@ -117,7 +117,7 @@ impl SftpOptions {
             .unwrap_or_else(|| NonZeroUsize::new(100).unwrap())
     }
 
-    /// Set the init buffer size for read_end.
+    /// Set the init buffer size for responses.
     /// If the header of the response is larger than the buffer, then the buffer
     /// will be resized to fit the size of the header.
     ///


### PR DESCRIPTION
Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>