### PR TITLE
Optimize `Queue` impl for `MpscQueue`: Avoid pushing empty `Bytes`

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -18,14 +18,20 @@ impl MpscQueue {
 
 impl Queue for MpscQueue {
     fn push(&self, bytes: Bytes) {
-        self.0.lock().unwrap().push(bytes);
+        if !bytes.is_empty() {
+            self.0.lock().unwrap().push(bytes);
+        }
     }
 
     fn extend(&self, header: Bytes, body: &[&[Bytes]]) {
         let mut v = self.0.lock().unwrap();
-        v.push(header);
+
+        if !header.is_empty() {
+            v.push(header);
+        }
+
         for data in body {
-            v.extend(data.iter().cloned());
+            v.extend(data.iter().filter(|bytes| !bytes.is_empty()).cloned());
         }
     }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -28,14 +28,14 @@ async fn flush<W: AsyncWrite>(
 ) -> Result<(), Error> {
     shared_data.queue().swap(backup_buffer);
 
-    // Remove all empty `Bytes`s so that:
+    // `Queue` implementation for `MpscQueue` already removes
+    // all empty `Bytes`s so that:
     //  - We can check for `io::ErrorKind::WriteZero` error easily
     //  - It won't occupy precise slot in `reusable_io_slices` so that
     //    we can group as many non-zero IoSlice in one write.
     //  - Avoid conserion from/to `VecDeque` unless necessary,
     //    which might allocate.
     //  - Simplify the loop below.
-    backup_buffer.retain(|bytes| !bytes.is_empty());
 
     if backup_buffer.is_empty() {
         return Ok(());


### PR DESCRIPTION
so that:
 - Precious space in `MpscQueue` won't be occupied by empty `Bytes`
 - `tasks::flush` would not have to call `Vec::retain`, which can be
   expensive.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>