### PR TITLE
Demonomorphize `create_read_task`

### DIFF
--- a/openssh-sftp-client-lowlevel/src/changelog.rs
+++ b/openssh-sftp-client-lowlevel/src/changelog.rs
@@ -3,11 +3,19 @@ use crate::*;
 
 #[doc(hidden)]
 /// ## Added
-///  - new trait `Queue`
+///  - new trait [`Queue`]
+///  - [`ReadEnd::new`] is now public
 ///
 /// ## Changed
-///  - `connect` now takes `queue` instead of `write_end_buffer_size`
-///  - `ReadEnd`, `WriteEnd` and `SharedData` now takes an additional generic
+///  - [`connect`] now takes `queue` instead of `write_end_buffer_size`
+///  - [`connect`] does not take `reader` and `reader_buffer_len` and it
+///    does not return [`ReadEnd`] anymore.
+///
+///    User has to manually call [`ReadEnd::new`] to create [`ReadEnd`].
+///
+///    This is done to give the user more freedom on how and when [`ReadEnd`]
+///    is created.
+///  - [`ReadEnd`], [`WriteEnd`] and [`SharedData`] now takes an additional generic
 ///    parameter `Q`.
 pub mod unreleased {}
 

--- a/openssh-sftp-client-lowlevel/src/read_end.rs
+++ b/openssh-sftp-client-lowlevel/src/read_end.rs
@@ -36,7 +36,10 @@ where
     R: AsyncRead,
     Buffer: ToBuffer + 'static + Send + Sync,
 {
-    pub(crate) fn new(
+    /// Must call [`ReadEnd::receive_server_hello_pinned`]
+    /// or [`ReadEnd::receive_server_hello`] after this
+    /// function call.
+    pub fn new(
         reader: R,
         reader_buffer_len: NonZeroUsize,
         shared_data: SharedData<Buffer, Q, Auxiliary>,
@@ -47,7 +50,7 @@ where
         }
     }
 
-    /// Must be called once right after `super::connect`
+    /// Must be called once right after [`ReadEnd::new`]
     /// to receive the hello message from the server.
     pub async fn receive_server_hello_pinned(
         mut self: Pin<&mut Self>,

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -7,6 +7,7 @@ use crate::*;
 ///  - Bump `openssh_sftp_client_lowlevel` version and optimize
 ///    write buffer implementation.
 ///  - Optimize: Reduce monomorphization
+///  - Optimize latency: `create_flush_task` first in `Sftp::new`
 pub mod unreleased {}
 
 /// Nothing has changed from [`v_0_11_0_rc_3`].

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -41,17 +41,17 @@ impl Sftp {
         )
         .await?;
 
-        let (rx, read_task) = create_read_task(
-            stdout,
-            options.get_read_end_buffer_size(),
-            SharedData::clone(&write_end),
-        );
-
         let flush_task = create_flush_task(
             stdin,
             SharedData::clone(&write_end),
             write_end_buffer_size,
             options.get_flush_interval(),
+        );
+
+        let (rx, read_task) = create_read_task(
+            stdout,
+            options.get_read_end_buffer_size(),
+            SharedData::clone(&write_end),
         );
 
         Self::init(flush_task, read_task, write_end, rx, &options).await

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -9,7 +9,7 @@ use auxiliary::Auxiliary;
 use lowlevel::{connect, Extensions};
 use tasks::{create_flush_task, create_read_task};
 
-use std::{cmp::min, convert::TryInto, ops::Deref, path::Path, sync::atomic::Ordering};
+use std::{cmp::min, convert::TryInto, path::Path, sync::atomic::Ordering};
 
 use derive_destructure2::destructure;
 use tokio::{
@@ -44,7 +44,7 @@ impl Sftp {
         let (rx, read_task) = create_read_task(
             stdout,
             options.get_read_end_buffer_size(),
-            write_end.deref().clone(),
+            SharedData::clone(&write_end),
         );
 
         let flush_task = create_flush_task(

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -174,7 +174,7 @@ pub(super) fn create_flush_task<W: AsyncWrite + Send + 'static>(
     }
 
     spawn(async move {
-        tokio::pin!(writer);
+        pin!(writer);
 
         inner(writer, shared_data, write_end_buffer_size, flush_interval).await
     })

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -118,7 +118,6 @@ pub(super) fn create_flush_task<W: AsyncWrite + Send + 'static>(
         let mut backup_queue_buffer = Vec::with_capacity(write_end_buffer_size.get());
         let mut reusable_io_slices = ReusableIoSlices::new(write_end_buffer_size);
 
-        // The loop can only return `Err`
         loop {
             flush_end_notify.notified().await;
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -182,11 +182,15 @@ pub(super) fn create_flush_task<W: AsyncWrite + Send + 'static>(
 }
 
 pub(super) fn create_read_task<R: AsyncRead + Send + 'static>(
-    read_end: ReadEnd<R>,
+    stdout: R,
+    read_end_buffer_size: NonZeroUsize,
+    shared_data: SharedData,
 ) -> (oneshot::Receiver<Extensions>, JoinHandle<Result<(), Error>>) {
     let (tx, rx) = oneshot::channel();
 
     let handle = spawn(async move {
+        let read_end = ReadEnd::new(stdout, read_end_buffer_size, shared_data);
+
         let shared_data = read_end.get_shared_data().clone();
         let auxiliary = shared_data.get_auxiliary();
         let read_end_notify = &auxiliary.read_end_notify;


### PR DESCRIPTION
 - `lowlevel::ReadEnd::new` is now public
 - `lowlevel::connect` now does not create the `ReadEnd`, giving user more freedom on how and when to create `ReadEnd`.
 - [Optimize create_read_task: Reduce monomorphization](https://github.com/openssh-rust/openssh-sftp-client/commit/45481b9cde843a04d1b2e668294400ff50a6421f)