### PR TITLE
Fix openssh-sftp-error: Ensure stable api

### DIFF
--- a/openssh-sftp-client-lowlevel/Cargo.toml
+++ b/openssh-sftp-client-lowlevel/Cargo.toml
@@ -13,7 +13,9 @@ keywords = ["ssh", "multiplex", "async", "network", "sftp"]
 categories = ["asynchronous", "network-programming", "api-bindings"]
 
 [dependencies]
-openssh-sftp-error = { version = "0.2.1", features = ["bytes"], path = "../openssh-sftp-error" }
+awaitable = "0.4.0"
+openssh-sftp-protocol = { version = "0.23.0", features = ["bytes"] }
+openssh-sftp-error = { version = "0.2.1", path = "../openssh-sftp-error" }
 concurrent_arena = "0.1.7"
 derive_destructure2 = "0.1.0"
 

--- a/openssh-sftp-client-lowlevel/src/awaitable_responses.rs
+++ b/openssh-sftp-client-lowlevel/src/awaitable_responses.rs
@@ -2,9 +2,9 @@
 
 use super::Error;
 
-use crate::openssh_sftp_protocol::response::ResponseInner;
 use concurrent_arena::Arena;
 use derive_destructure2::destructure;
+use openssh_sftp_protocol::response::ResponseInner;
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -25,7 +25,7 @@ pub(crate) enum Response<Buffer> {
     ExtendedReply(Box<[u8]>),
 }
 
-pub(crate) type Awaitable<Buffer> = crate::awaitable::Awaitable<Buffer, Response<Buffer>>;
+pub(crate) type Awaitable<Buffer> = awaitable::Awaitable<Buffer, Response<Buffer>>;
 
 /// BITARRAY_LEN must be LEN / usize::BITS and LEN must be divisble by usize::BITS.
 const BITARRAY_LEN: usize = 2;

--- a/openssh-sftp-client-lowlevel/src/awaitables.rs
+++ b/openssh-sftp-client-lowlevel/src/awaitables.rs
@@ -11,11 +11,11 @@ use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::openssh_sftp_protocol::file_attrs::FileAttrs;
-use crate::openssh_sftp_protocol::response::{NameEntry, ResponseInner, StatusCode};
-use crate::openssh_sftp_protocol::ssh_format;
-use crate::openssh_sftp_protocol::HandleOwned;
 use derive_destructure2::destructure;
+use openssh_sftp_protocol::file_attrs::FileAttrs;
+use openssh_sftp_protocol::response::{NameEntry, ResponseInner, StatusCode};
+use openssh_sftp_protocol::ssh_format;
+use openssh_sftp_protocol::HandleOwned;
 
 /// The data returned by [`WriteEnd::send_read_request`].
 #[derive(Debug, Clone)]

--- a/openssh-sftp-client-lowlevel/src/connection.rs
+++ b/openssh-sftp-client-lowlevel/src/connection.rs
@@ -4,7 +4,7 @@ use super::{awaitable_responses::AwaitableResponses, *};
 
 use std::{fmt::Debug, sync::Arc};
 
-use crate::openssh_sftp_protocol::constants::SSH2_FILEXFER_VERSION;
+use openssh_sftp_protocol::constants::SSH2_FILEXFER_VERSION;
 
 // TODO:
 //  - Support for zero copy syscalls

--- a/openssh-sftp-client-lowlevel/src/lib.rs
+++ b/openssh-sftp-client-lowlevel/src/lib.rs
@@ -30,7 +30,6 @@ mod reader_buffered;
 mod write_end;
 
 pub use openssh_sftp_error::Error;
-use openssh_sftp_error::{awaitable, openssh_sftp_protocol};
 
 /// Default size of buffer for up/download in openssh-portable
 pub const OPENSSH_PORTABLE_DEFAULT_COPY_BUFLEN: usize = 32768;

--- a/openssh-sftp-client-lowlevel/src/read_end.rs
+++ b/openssh-sftp-client-lowlevel/src/read_end.rs
@@ -13,10 +13,10 @@ use std::io;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 
-use crate::openssh_sftp_protocol::constants::SSH2_FILEXFER_VERSION;
-use crate::openssh_sftp_protocol::response::{self, ServerVersion};
-use crate::openssh_sftp_protocol::serde::de::DeserializeOwned;
-use crate::openssh_sftp_protocol::ssh_format::{self, from_bytes};
+use openssh_sftp_protocol::constants::SSH2_FILEXFER_VERSION;
+use openssh_sftp_protocol::response::{self, ServerVersion};
+use openssh_sftp_protocol::serde::de::DeserializeOwned;
+use openssh_sftp_protocol::ssh_format::{self, from_bytes};
 
 use pin_project::pin_project;
 use tokio::io::{copy_buf, sink, AsyncBufReadExt, AsyncRead, AsyncReadExt};

--- a/openssh-sftp-client-lowlevel/src/write_end.rs
+++ b/openssh-sftp-client-lowlevel/src/write_end.rs
@@ -12,12 +12,12 @@ use std::io::IoSlice;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 
-use crate::openssh_sftp_protocol::file_attrs::FileAttrs;
-use crate::openssh_sftp_protocol::request::*;
-use crate::openssh_sftp_protocol::serde::Serialize;
-use crate::openssh_sftp_protocol::ssh_format::Serializer;
-use crate::openssh_sftp_protocol::Handle;
 use bytes::{BufMut, Bytes, BytesMut};
+use openssh_sftp_protocol::file_attrs::FileAttrs;
+use openssh_sftp_protocol::request::*;
+use openssh_sftp_protocol::serde::Serialize;
+use openssh_sftp_protocol::ssh_format::Serializer;
+use openssh_sftp_protocol::Handle;
 
 /// It is recommended to create at most one `WriteEnd` per thread
 /// using [`WriteEnd::clone`].

--- a/openssh-sftp-error/Cargo.toml
+++ b/openssh-sftp-error/Cargo.toml
@@ -14,10 +14,8 @@ categories = ["asynchronous", "network-programming", "api-bindings"]
 
 [dependencies]
 thiserror = "1.0.29"
-awaitable = "0.4.0"
-openssh-sftp-protocol = "0.23.0"
+awaitable-error = "0.1.0"
+openssh-sftp-protocol-error = "0.1.0"
+ssh_format_error = "0.1.0"
 
 tokio = { version = "1.11.0", features = ["rt"] }
-
-[features]
-bytes = ["openssh-sftp-protocol/bytes"]

--- a/openssh-sftp-error/src/lib.rs
+++ b/openssh-sftp-error/src/lib.rs
@@ -2,13 +2,10 @@
 
 use std::{io, num::TryFromIntError, process::ExitStatus};
 
+pub use awaitable_error::Error as AwaitableError;
+pub use openssh_sftp_protocol_error::{ErrMsg as SftpErrMsg, ErrorCode as SftpErrorKind};
+pub use ssh_format_error::Error as SshFormatError;
 use thiserror::Error;
-
-pub use awaitable;
-
-pub use openssh_sftp_protocol;
-use openssh_sftp_protocol::ssh_format;
-pub use openssh_sftp_protocol::{ErrMsg as SftpErrMsg, ErrorCode as SftpErrorKind};
 
 /// Error returned by
 /// [`openssh-sftp-client-lowlevel`](https://docs.rs/openssh-sftp-client-lowlevel)
@@ -57,11 +54,11 @@ pub enum Error {
 
     /// Failed to serialize/deserialize the message: {0}.
     #[error("Failed to serialize/deserialize the message: {0}.")]
-    FormatError(#[from] ssh_format::Error),
+    FormatError(#[from] SshFormatError),
 
     /// Error when waiting for response
     #[error("Error when waiting for response: {0}.")]
-    AwaitableError(#[from] awaitable::Error),
+    AwaitableError(#[from] AwaitableError),
 
     /// Sftp protocol can only send and receive at most [`u32::MAX`] data in one request.
     #[error("Sftp protocol can only send and receive at most u32::MAX data in one request.")]

--- a/openssh-sftp-error/src/lib.rs
+++ b/openssh-sftp-error/src/lib.rs
@@ -1,8 +1,6 @@
 #![forbid(unsafe_code)]
 
-use std::io;
-use std::num::TryFromIntError;
-use std::process::ExitStatus;
+use std::{io, num::TryFromIntError, process::ExitStatus};
 
 use thiserror::Error;
 


### PR DESCRIPTION
by using dep:
 - awaitable-error instead of awaitable
 - openssh-sftp-protocol-error instead of openssh-sftp-protocol
 - ssh_format_error instead of ssh_format

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>