### PR TITLE
Ensure stable api: Create newtype wrapper of `UnixTimeStamp`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,10 @@ pub use error::{Error, UnixTimeStampError};
 use openssh_sftp_client_lowlevel as lowlevel;
 pub use openssh_sftp_error as error;
 
-pub use lowlevel::UnixTimeStamp;
-
 use bytes::BytesMut;
+
+mod unix_timestamp;
+pub use unix_timestamp::UnixTimeStamp;
 
 mod sftp;
 pub use sftp::Sftp;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -103,7 +103,10 @@ impl MetaData {
     /// Return `None` if the server did not return
     /// the last access time.
     pub fn accessed(&self) -> Option<UnixTimeStamp> {
-        self.0.get_time().map(|(atime, _mtime)| atime)
+        self.0
+            .get_time()
+            .map(|(atime, _mtime)| atime)
+            .map(UnixTimeStamp)
     }
 
     /// Returns the last modification time.
@@ -111,7 +114,10 @@ impl MetaData {
     /// Return `None` if the server did not return
     /// the last modification time.
     pub fn modified(&self) -> Option<UnixTimeStamp> {
-        self.0.get_time().map(|(_atime, mtime)| mtime)
+        self.0
+            .get_time()
+            .map(|(_atime, mtime)| mtime)
+            .map(UnixTimeStamp)
     }
 }
 

--- a/src/unix_timestamp.rs
+++ b/src/unix_timestamp.rs
@@ -1,0 +1,42 @@
+use super::{lowlevel, UnixTimeStampError};
+use std::time::{Duration, SystemTime};
+
+/// Default value is 1970-01-01 00:00:00 UTC.
+///
+/// UnixTimeStamp stores number of seconds elapsed since 1970-01-01 00:00:00 UTC
+/// as `u32`.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct UnixTimeStamp(pub(crate) lowlevel::UnixTimeStamp);
+
+impl UnixTimeStamp {
+    /// Create new unix timestamp from `system_time`.
+    pub fn new(system_time: SystemTime) -> Result<Self, UnixTimeStampError> {
+        lowlevel::UnixTimeStamp::new(system_time).map(Self)
+    }
+
+    /// Return unix epoch, same as [`UnixTimeStamp::default`]
+    pub const fn unix_epoch() -> Self {
+        Self(lowlevel::UnixTimeStamp::unix_epoch())
+    }
+
+    /// Return `None` if [`std::time::SystemTime`] cannot hold the timestamp.
+    pub fn from_raw(elapsed: u32) -> Option<Self> {
+        lowlevel::UnixTimeStamp::from_raw(elapsed).map(Self)
+    }
+
+    /// Into `u32` which is used to internally store the timestamp in seconds.
+    pub fn into_raw(self) -> u32 {
+        self.0.into_raw()
+    }
+
+    /// Convert timestamp to [`Duration`].
+    pub fn as_duration(self) -> Duration {
+        self.0.as_duration()
+    }
+
+    /// Convert timestamp back to [`SystemTime`].
+    pub fn as_system_time(self) -> SystemTime {
+        self.0.as_system_time()
+    }
+}


### PR DESCRIPTION
to ensure that even if a new major version of openssh-sftp-protocol is released, openssh-sftp-client can still release a minor version instead a major version as well.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>