### PR TITLE
Fix `openssh_sftp_client::fs::Dir::read_dir`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1.11.0", features = ["sync", "time", "rt", "macros"] }
 derive_destructure2 = "0.1.0"
 bytes = "1.2.1"
 tokio-io-utility = "0.7.4"
-tokio-util = "0.7.0"
+tokio-util = "0.7.8"
 
 futures-core = "0.3.28"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ bytes = "1.2.1"
 tokio-io-utility = "0.7.4"
 tokio-util = "0.7.0"
 
+futures-core = "0.3.28"
+
 scopeguard = "1.1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ bytes = "1.2.1"
 tokio-io-utility = "0.7.4"
 tokio-util = "0.7.8"
 
+pin-project = "1.0.10"
 futures-core = "0.3.28"
 
 scopeguard = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,4 @@ tokio = { version = "1.11.0", features = ["rt", "macros"] }
 tempfile = "3.1.0"
 pretty_assertions = "1.1.0"
 sftp-test-common = { path = "sftp-test-common" }
+futures-util = "0.3.28"

--- a/openssh-sftp-client-lowlevel/src/write_end.rs
+++ b/openssh-sftp-client-lowlevel/src/write_end.rs
@@ -212,10 +212,14 @@ where
             .map(AwaitableHandle::new)
     }
 
-    /// Return all entries in the directory specified by the `handle`, including
+    /// Return entries in the directory specified by the `handle`, including
     /// `.` and `..`.
     ///
     /// The `filename` only contains the basename.
+    ///
+    /// **NOTE that it does not return all entries in one response.**
+    /// You would have to keep calling `send_readdir_request` until it returns
+    /// an empty `Box`.
     pub fn send_readdir_request(
         &mut self,
         id: Id<Buffer>,

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -8,8 +8,8 @@ export RUNTIME_DIR=${XDG_RUNTIME_DIR:-/tmp}
 
 for workspace in openssh-sftp-error openssh-sftp-client-lowlevel; do
     cd "$workspace"
-    cargo test "$@" --all-features
+    cargo test --all-features "$@"
     cd ..
 done
 
-exec cargo test "$@" --all-features
+exec cargo test --all-features "$@"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -9,7 +9,7 @@ use std::{
 #[derive(Debug)]
 pub(super) struct WriteEndWithCachedId<'s> {
     sftp: &'s Sftp,
-    inner: WriteEnd,
+    pub(super) inner: WriteEnd,
     id: Option<Id>,
 }
 
@@ -64,29 +64,29 @@ impl<'s> WriteEndWithCachedId<'s> {
         F: Future<Output = Result<R, E>> + Send,
         E: Into<Error> + Send,
     {
-        async fn inner<R>(
-            this: &mut WriteEndWithCachedId<'_>,
-            future: Pin<&mut (dyn Future<Output = Result<R, Error>> + Send)>,
-        ) -> Result<R, Error> {
-            let cancel_err = || Err(BoxedWaitForCancellationFuture::cancel_error());
-            let auxiliary = this.sftp.auxiliary();
-
-            let cancel_token = &auxiliary.cancel_token;
-
-            if cancel_token.is_cancelled() {
-                return cancel_err();
-            }
-
-            tokio::select! {
-                res = future => res,
-                _ = cancel_token.cancelled() => cancel_err(),
-            }
-        }
-
         let future = async move { future.await.map_err(Into::into) };
         tokio::pin!(future);
 
-        inner(self, future).await
+        self.cancel_if_task_failed_inner(future).await
+    }
+
+    pub(super) async fn cancel_if_task_failed_inner<R>(
+        &mut self,
+        future: Pin<&mut (dyn Future<Output = Result<R, Error>> + Send)>,
+    ) -> Result<R, Error> {
+        let cancel_err = || Err(BoxedWaitForCancellationFuture::cancel_error());
+        let auxiliary = self.sftp.auxiliary();
+
+        let cancel_token = &auxiliary.cancel_token;
+
+        if cancel_token.is_cancelled() {
+            return cancel_err();
+        }
+
+        tokio::select! {
+            res = future => res,
+            _ = cancel_token.cancelled() => cancel_err(),
+        }
     }
 
     pub(super) fn get_auxiliary(&self) -> &'s Auxiliary {
@@ -115,7 +115,7 @@ impl<'s> WriteEndWithCachedId<'s> {
             future: Pin<&mut (dyn Future<Output = Result<(Id, R), Error>> + Send)>,
         ) -> Result<R, Error> {
             // Requests is already added to write buffer, so wakeup
-            // the `flush_task`.
+            // the `flush_task` if necessary.
             this.get_auxiliary().wakeup_flush_task();
 
             let (id, ret) = this.cancel_if_task_failed(future).await?;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -84,8 +84,10 @@ impl<'s> WriteEndWithCachedId<'s> {
         }
 
         tokio::select! {
-            res = future => res,
+            biased;
+
             _ = cancel_token.cancelled() => cancel_err(),
+            res = future => res,
         }
     }
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -374,15 +374,10 @@ impl<'s> Fs<'s> {
 #[derive(Debug, Clone)]
 pub struct Dir<'s>(OwnedHandle<'s>);
 
-impl Dir<'_> {
+impl<'s> Dir<'s> {
     /// Read dir.
-    pub async fn read_dir(&mut self) -> Result<ReadDir, Error> {
-        self.0
-            .send_request(|write_end, handle, id| {
-                Ok(write_end.send_readdir_request(id, handle)?.wait())
-            })
-            .await
-            .map(ReadDir::new)
+    pub fn read_dir(self) -> ReadDir<'s> {
+        ReadDir::new(self)
     }
 
     /// Close dir.

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -113,6 +113,8 @@ pub(super) fn create_flush_task<W: AsyncWrite + Send + 'static>(
             flush_end_notify.notified().await;
 
             tokio::select! {
+                biased;
+
                 _ = interval.tick() => (),
                 // tokio::sync::Notify is cancel safe, however
                 // cancelling it would lose the place in the queue.


### PR DESCRIPTION
Fixed #62

 -  Fix doc of `WriteEnd::send_readdir_request`
 - Add new dep `futures-core` v0.3.28
 - Refactor: Extract new fn `WriteEndWithCachedId::cancel_if_task_failed_inner`
 - Bump `tokio-util` v0.7.0 => v0.7.8
 - Add `pin-project` v1.0.10 to `openssh-sftp-client`
 - Optimize use of `tokio::select!`: make them `biased`
    There is no need for randomisation.
 - Add new dev-dep `futures-util` v0.3.28
 - Fix `Dir::read_dir`: Issue multiple `send_readdir_request` requests until eof
   `ReadDir` now implements `Stream` and `FusedStream` and has a similar interface to
   `tokio::fs::ReadDir`
 - Fix `run_tests.sh`: Allow passing `-- --nocapture` for `cargo-test`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>