### PR TITLE
Keep waiting on other tasks on failure in `Sftp::close`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain

--- a/TODO.md
+++ b/TODO.md
@@ -3,4 +3,3 @@
  - Use [`buf-list`](https://docs.rs/buf-list) to archive zero-copy using `Sink` trait
  - Cleanup dependabot
  - Add optional logging support
- - Improve `Sftp::close`: Return all errors if possible

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -5,6 +5,10 @@ use crate::*;
 ///  - `OpensshSession`
 ///  - `SftpAuxiliaryData::ArcedOpensshSession`
 ///  - `Sftp::from_session`
+///
+/// ## Improved
+///  - Keep waiting on other tasks on failure in [`Sftp::close`]
+///    to collect as much information about the failure as possible.
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@
 /// Changelog for this crate.
 pub mod changelog;
 
+mod utils;
+
 pub use error::{Error, UnixTimeStampError};
 use openssh_sftp_client_lowlevel as lowlevel;
 pub use openssh_sftp_error as error;

--- a/src/sftp/openssh_session.rs
+++ b/src/sftp/openssh_session.rs
@@ -3,10 +3,7 @@ use std::sync::Arc;
 use openssh::Stdio;
 use tokio::{sync::oneshot, task::JoinHandle};
 
-use crate::{
-    error::{Error, RecursiveError},
-    Sftp, SftpAuxiliaryData, SftpOptions,
-};
+use crate::{utils::ErrorExt, Error, Sftp, SftpAuxiliaryData, SftpOptions};
 
 /// The openssh session
 #[derive(Debug)]
@@ -61,10 +58,7 @@ impl Sftp {
 
             match (original_error, occuring_error) {
                 (Some(original_error), Some(occuring_error)) => {
-                    Some(Error::RecursiveErrors(Box::new(RecursiveError {
-                        original_error,
-                        occuring_error,
-                    })))
+                    Some(original_error.error_on_cleanup(occuring_error))
                 }
                 (Some(err), None) | (None, Some(err)) => Some(err),
                 (None, None) => None,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,29 @@
+use std::convert::identity;
+
+use crate::error::{Error, RecursiveError};
+
+pub trait ErrorExt {
+    fn error_on_cleanup(self, occuring_error: Error) -> Self;
+}
+
+impl ErrorExt for Error {
+    fn error_on_cleanup(self, occuring_error: Error) -> Self {
+        Error::RecursiveErrors(Box::new(RecursiveError {
+            original_error: self,
+            occuring_error,
+        }))
+    }
+}
+
+pub trait ResultExt<T, E> {
+    fn flatten(self) -> Result<T, E>;
+}
+
+impl<T, E, E2> ResultExt<T, E> for Result<Result<T, E>, E2>
+where
+    E: From<E2>,
+{
+    fn flatten(self) -> Result<T, E> {
+        self.map_err(E::from).and_then(identity)
+    }
+}


### PR DESCRIPTION
to collect as much information about the failure as possible.

Also, run `cargo check --features __ci-tests` on Linux to make sure the openssh-sftp-client compiles without feature `openssh`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>