### PR TITLE
Make `openssh_sftp_client_lowlevel::connect` regular fn

### DIFF
--- a/openssh-sftp-client-lowlevel/src/connection.rs
+++ b/openssh-sftp-client-lowlevel/src/connection.rs
@@ -88,7 +88,7 @@ impl<Buffer: Send + Sync, Q, Auxiliary> SharedData<Buffer, Q, Auxiliary> {
 /// This function is not cancel safe.
 ///
 /// After dropping the future, the connection would be in a undefined state.
-pub async fn connect<Buffer, Q, Auxiliary>(
+pub fn connect<Buffer, Q, Auxiliary>(
     queue: Q,
     auxiliary: Auxiliary,
 ) -> Result<WriteEnd<Buffer, Q, Auxiliary>, Error>
@@ -100,7 +100,7 @@ where
 
     // Send hello message
     let mut write_end = WriteEnd::new(shared_data);
-    write_end.send_hello(SSH2_FILEXFER_VERSION).await?;
+    write_end.send_hello(SSH2_FILEXFER_VERSION)?;
 
     Ok(write_end)
 }

--- a/openssh-sftp-client-lowlevel/src/write_end.rs
+++ b/openssh-sftp-client-lowlevel/src/write_end.rs
@@ -67,7 +67,7 @@ where
     Buffer: Send + Sync,
     Q: Queue,
 {
-    pub(crate) async fn send_hello(&mut self, version: u32) -> Result<(), Error> {
+    pub(crate) fn send_hello(&mut self, version: u32) -> Result<(), Error> {
         self.shared_data
             .queue()
             .push(Self::serialize(&mut self.serializer, Hello { version })?);

--- a/openssh-sftp-client-lowlevel/tests/lowlevel.rs
+++ b/openssh-sftp-client-lowlevel/tests/lowlevel.rs
@@ -31,7 +31,7 @@ async fn flush(read_end: &mut ReadEnd) {
     let mut stdin_locked = stdin.lock().await;
 
     for byte in bytes {
-        stdin_locked.write_all(&*byte).await.unwrap();
+        stdin_locked.write_all(&byte).await.unwrap();
     }
 }
 
@@ -40,9 +40,7 @@ async fn connect_with_extensions() -> (WriteEnd, ReadEnd, process::Child, Extens
 
     let buffer_size = NonZeroUsize::new(1000).unwrap();
 
-    let write_end = lowlevel::connect(MpscQueue::default(), Mutex::new(stdin))
-        .await
-        .unwrap();
+    let write_end = lowlevel::connect(MpscQueue::default(), Mutex::new(stdin)).unwrap();
 
     let mut read_end = ReadEnd::new(stdout, buffer_size, write_end.deref().clone());
 

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -145,8 +145,7 @@ impl Sftp {
                 write_end_buffer_size.get(),
                 options.get_max_pending_requests(),
                 auxiliary,
-            ))
-            .await?;
+            ))?;
 
             let flush_task = create_flush_task(
                 stdin,
@@ -166,7 +165,7 @@ impl Sftp {
         .await
     }
 
-    async fn connect(
+    fn connect(
         write_end_buffer_size: usize,
         max_pending_requests: u16,
         auxiliary: SftpAuxiliaryData,
@@ -175,7 +174,6 @@ impl Sftp {
             MpscQueue::with_capacity(write_end_buffer_size),
             Auxiliary::new(max_pending_requests, auxiliary),
         )
-        .await
     }
 
     async fn init(


### PR DESCRIPTION
And also make `WriteEnd::send_hello` a regular fn since they do not use async functionality anyway.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>