### PR TITLE
fix invalid response id after closing file

### DIFF
--- a/openssh-sftp-client-lowlevel/src/read_end.rs
+++ b/openssh-sftp-client-lowlevel/src/read_end.rs
@@ -211,6 +211,11 @@ where
             Err(err) => {
                 drop(drain);
 
+                if packet_type == openssh_sftp_protocol::constants::SSH_FXP_STATUS {
+                    let _ = self.consume_packet(len, err).await;
+                    return Ok(());
+                }
+
                 // Consume the invalid data to return self to a valid state
                 // where read_in_one_packet can be called again.
                 return self.consume_packet(len, err).await;

--- a/openssh-sftp-client-lowlevel/src/read_end.rs
+++ b/openssh-sftp-client-lowlevel/src/read_end.rs
@@ -211,11 +211,6 @@ where
             Err(err) => {
                 drop(drain);
 
-                if packet_type == openssh_sftp_protocol::constants::SSH_FXP_STATUS {
-                    let _ = self.consume_packet(len, err).await;
-                    return Ok(());
-                }
-
                 // Consume the invalid data to return self to a valid state
                 // where read_in_one_packet can be called again.
                 return self.consume_packet(len, err).await;

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -2,7 +2,7 @@
 use crate::*;
 
 /// ## Improved
-/// - Fix [`OwnedHandle::drop`]: change it to wait for the close request in order to
+/// - Fix: change the drop of `OwnedHandle` to wait for the close request in order to
 ///   avoid invalid response id after closing file
 #[doc(hidden)]
 pub mod unreleased {}

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,9 @@
 #[allow(unused_imports)]
 use crate::*;
 
+/// ## Improved
+/// - Fix [`OwnedHandle::drop`]: change it to wait for the close request in order to
+///   avoid invalid response id after closing file
 #[doc(hidden)]
 pub mod unreleased {}
 


### PR DESCRIPTION
Sometimes after closing file, the server will send success message later. At this time, if we have removed `response_id` from `SharedData`, it will raise the error of `invalid_response_id`.