### PR TITLE
Release openssh-sftp-client v0.13.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "openssh-sftp-client"
-version = "0.13.3"
-edition = "2018"
+version = "0.13.4"
+edition = "2021"
+rust-version = "1.64"
 
 authors = ["Jiahao XU <Jiahao_XU@outlook.com>"]
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,11 +1,18 @@
 #[allow(unused_imports)]
 use crate::*;
 
+#[doc(hidden)]
+pub mod unreleased {}
+
 /// ## Improved
 /// - Fix: change the drop of `OwnedHandle` to wait for the close request in order to
 ///   avoid invalid response id after closing file
-#[doc(hidden)]
-pub mod unreleased {}
+/// - Add log for droping OwnedHandle
+///
+/// ## Other changes
+/// - Add msrv 1.64 in `Cargo.toml`
+/// - Bump `edition` to 2021 in `Cargo.toml`
+pub mod v_0_13_4 {}
 
 /// ## Improved
 ///  - If `Sftp` is created using `Sftp::from_session`, then dropping it would


### PR DESCRIPTION
We should wait #78 merged first, and then release a new version.

Explanation of msrv:

https://github.com/openssh-rust/openssh-sftp-client/blob/8a1e0cb03a8cae58e41ea76c8a2bbaa43d5584a9/src/fs/dir.rs#L141
It uses feature 'ready_macro', which is stable in 1.64