### PR TITLE
Fix `AsyncSeek` of `TokioCompatFile`

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,9 @@
 #[allow(unused_imports)]
 use crate::*;
 
+/// ## Fixed
+///  - Fixed #80 [`file::TokioCompatFile`]: Incorrect behavior about `AsyncSeek`
+///  - Fixed [`file::TokioCompatFile`]: leave error of exceeding buffer len in `consume` to handle by `BytesMut`
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -354,7 +354,7 @@ impl AsyncSeek for TokioCompatFile {
                 if offset > this.buffer.len() {
                     this.buffer.clear();
                 } else {
-                    self.consume(offset);
+                    this.buffer.advance(offset);
                 }
             } else {
                 this.buffer.clear();

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -351,7 +351,11 @@ impl AsyncSeek for TokioCompatFile {
             if new_offset < prev_offset {
                 this.buffer.clear();
             } else if let Ok(offset) = (new_offset - prev_offset).try_into() {
-                self.consume(offset);
+                if offset > this.buffer.len() {
+                    this.buffer.clear();
+                } else {
+                    self.consume(offset);
+                }
             } else {
                 this.buffer.clear();
             }
@@ -384,7 +388,6 @@ impl AsyncBufRead for TokioCompatFile {
         let this = self.project();
 
         let buffer = this.buffer;
-        let amt = min(buffer.len(), amt);
 
         buffer.advance(amt);
         this.inner.offset += amt as u64;


### PR DESCRIPTION
Close #80 

Update:
- Fix the incorrect behavior about `AsyncSeek` in `file::TokioCompatFile`
- leave error of exceeding buffer len in `consume` to handle by `BytesMut`

About the bug of `AsyncSeek`, I find a simpler solution. Since we won't use the buffer after seeking, we can just clear the buffer like `new_offset < prev_offset` situation.