### PR TITLE
Fix `TokioCompatFile`: Impl `PinnedDrop`

### DIFF
--- a/openssh-sftp-client-lowlevel/src/awaitables.rs
+++ b/openssh-sftp-client-lowlevel/src/awaitables.rs
@@ -133,6 +133,15 @@ macro_rules! def_awaitable {
         }
 
         /// Awaitable
+        ///
+        /// You must call `wait()` and poll the return future to end, otherwise
+        /// the request/response id might be dropped early and
+        /// [`ReadEnd::read_in_one_packet_pinned`] or
+        /// [`ReadEnd::read_in_one_packet`] might fail due to unexpected
+        /// response id.
+        ///
+        /// Alternatively, you can choose to ignore these errors, but it's not
+        /// recommended.
         #[repr(transparent)]
         #[derive(Debug)]
         pub struct $name<Buffer: Send + Sync>(AwaitableInner<Buffer>);

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -4,6 +4,9 @@ use crate::*;
 /// ## Fixed
 ///  - Fixed #80 [`file::TokioCompatFile`]: Incorrect behavior about `AsyncSeek`
 ///  - Fixed [`file::TokioCompatFile`]: leave error of exceeding buffer len in `consume` to handle by `BytesMut`
+///  - Fixed `TokioCompatFile`: Implement `PinnedDrop` to poll read and write futures to end,
+///    otherwise it would drop the internal request ids too early, causing read task to fail
+///    when they should not fail.
 #[doc(hidden)]
 pub mod unreleased {}
 


### PR DESCRIPTION
Implement `PinnedDrop` to poll read and write futures to end, otherwise it would drop the internal request ids too early, causing read task to fail when they should not fail.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>