### PR TITLE
Fixed `fs::ReadDir`: Implement `PinnedDrop`

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -4,7 +4,10 @@ use crate::*;
 /// ## Fixed
 ///  - Fixed #80 [`file::TokioCompatFile`]: Incorrect behavior about `AsyncSeek`
 ///  - Fixed [`file::TokioCompatFile`]: leave error of exceeding buffer len in `consume` to handle by `BytesMut`
-///  - Fixed `TokioCompatFile`: Implement `PinnedDrop` to poll read and write futures to end,
+///  - Fixed [`file::TokioCompatFile`]: Implement `PinnedDrop` to poll read and write futures to end,
+///    otherwise it would drop the internal request ids too early, causing read task to fail
+///    when they should not fail.
+///  - Fixed [`fs::ReadDir`]: Implement `PinnedDrop` to poll future stored internally,
 ///    otherwise it would drop the internal request ids too early, causing read task to fail
 ///    when they should not fail.
 #[doc(hidden)]


### PR DESCRIPTION
Implement `PinnedDrop` to poll future stored internally, otherwise it would drop the internal request ids too early, causing read task to fail when they should not fail.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>