### PR TITLE
Fix invalid behavior in `ReaderBuffered::consume`

### DIFF
--- a/openssh-sftp-client-lowlevel/src/changelog.rs
+++ b/openssh-sftp-client-lowlevel/src/changelog.rs
@@ -2,7 +2,7 @@
 use crate::*;
 
 /// ## Changed
-///  - Fix [`ReaderBuffered`]: Leave error of exceeding buffer len in `consume` to handle by `BytesMut`
+///  - Fix: Leave error of exceeding buffer len in `ReaderBuffered::consume` to handle by `BytesMut`
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/openssh-sftp-client-lowlevel/src/changelog.rs
+++ b/openssh-sftp-client-lowlevel/src/changelog.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use crate::*;
 
+/// ## Changed
+///  - Fix [`ReaderBuffered`]: Leave error of exceeding buffer len in `consume` to handle by `BytesMut`
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/openssh-sftp-client-lowlevel/src/reader_buffered.rs
+++ b/openssh-sftp-client-lowlevel/src/reader_buffered.rs
@@ -94,9 +94,6 @@ impl<R: AsyncRead> AsyncBufRead for ReaderBuffered<R> {
     fn consume(self: Pin<&mut Self>, amt: usize) {
         let buffer = &mut self.project().buffer;
 
-        let len = buffer.len();
-        let amt = min(len, amt);
-
         buffer.advance(amt);
     }
 }


### PR DESCRIPTION
We only uses it in https://github.com/openssh-rust/openssh-sftp-client/blob/b5e6dce1c6d7ad1f7c43ae337225edb4fb933218/openssh-sftp-client-lowlevel/src/reader_buffered.rs#L128

And in `poll_read` function, it maintains the remaining lens of buffer to deal with the exceeding buffer len error. As a result, we can change `ReaderBuffered::consume` directly.