### PR TITLE
Improve CI: Speedup & more tests, and fixed one clippy warning

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,13 @@
 name: Rust
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
+  RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
@@ -21,31 +28,42 @@ on:
 
 jobs:
   os-check:
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    name: os check on ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - { target: x86_64-pc-windows-msvc, args: "--exclude-features openssh" }
+          - { target: x86_64-apple-darwin }
+          - { target: x86_64-unknown-linux-gnu }
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
-        run: rustup toolchain install stable --no-self-update --profile minimal
+        run: |
+          rustup toolchain install stable --no-self-update --profile minimal --target ${{ matrix.target }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
 
       - name: Create Cargo.lock for caching
         run: cargo update
       - uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-index-
+          key: cargo-index-os-check-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-index-os-check-${{ matrix.target }}
+            cargo-index-os-check-
+            cargo-index-
+
       - uses: mozilla-actions/sccache-action@v0.0.3
 
-      - run: cargo check --features __ci-tests
+      - run: |
+          cargo hack check --feature-powerset --target ${{ matrix.target }} ${{ matrix.args }}
 
   check:
     runs-on: ubuntu-latest
@@ -64,17 +82,16 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: |
-          ~/.cargo/bin/
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-index-
+        key: cargo-index-check-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-index-check-
+          cargo-index-
     - uses: mozilla-actions/sccache-action@v0.0.3
 
     - run: ./check.sh
-      env:
-        RUSTDOCFLAGS: -Dwarnings
 
   build:
     runs-on: ubuntu-latest
@@ -92,12 +109,13 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: |
-          ~/.cargo/bin/
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-index-
+        key: cargo-index-build-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-index-build-
+          cargo-index-
     - uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Compile tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing = ["dep:tracing"]
 __ci-tests = []
 
 [package.metadata.docs.rs]
-features = ["openssh"]
+features = ["openssh", "tracing"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/check.sh
+++ b/check.sh
@@ -1,22 +1,16 @@
 #!/bin/bash
 
-run_check() {
-    cargo fmt --all -- --check
-    cargo clippy --all-features --all --no-deps
-    cargo doc --no-deps
-}
-
 set -euxo pipefail
 
 cd "$(dirname "$(realpath "$0")")"
 
-for workspace in openssh-sftp-error openssh-sftp-client-lowlevel; do
-    cd "$workspace"
-    run_check
-    cd ..
-done
-
-run_check
+cargo fmt --all -- --check
+cargo clippy --all-features --all --no-deps
 
 export RUSTDOCFLAGS="--cfg docsrs"
-exec cargo +nightly doc --no-deps --features openssh
+exec cargo +nightly doc \
+    --no-deps \
+    --features openssh,tracing \
+    --package openssh-sftp-client \
+    --package openssh-sftp-error \
+    --package openssh-sftp-client-lowlevel

--- a/src/sftp/openssh_session.rs
+++ b/src/sftp/openssh_session.rs
@@ -72,12 +72,12 @@ async fn create_session_task(
         );
     }
 
-    let session_str = format!("{session:?}");
+    let _session_str = format!("{session:?}");
     let occuring_error = session.close().await.err().map(Error::from);
 
     #[cfg(feature = "tracing")]
     if let Some(err) = &occuring_error {
-        tracing::error!("Closing session failed: {err}, session = {session_str}");
+        tracing::error!("Closing session failed: {err}, session = {_session_str}");
     }
 
     match (original_error, occuring_error) {


### PR DESCRIPTION
 - Speedup job `os-check`: Run on Linux Windows CI is just way too slow and this crate does not use anything that requires C/C++ compiler, so we can trivally cross-compile it.
 - Test features-powerset in job `os-check`
 - Turn warnings into errors
 - Add concurrency group to cancel CI for outdated commits
 - Make sure each job has its own unique cache key (for each matrix) and could restore from previous (`Cargo.lock`) or other jobs' cache as a fallback.
 - Fix docs.rs: Enable feature tracing
 - Speedup `check.sh`: Run fmt, clippy, doc once instead of multiple times