### PR TITLE
feat: add write buffer limit for tokio compat file

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,4 +6,4 @@ cd "$(dirname "$(realpath "$0")")"
 
 export RUNTIME_DIR=${XDG_RUNTIME_DIR:-/tmp}
 
-exec cargo test --all-features --workspace "$@" -- --show-output
+exec cargo test --all-features --workspace "$@"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,4 +6,4 @@ cd "$(dirname "$(realpath "$0")")"
 
 export RUNTIME_DIR=${XDG_RUNTIME_DIR:-/tmp}
 
-exec cargo test --all-features --workspace "$@"
+exec cargo test --all-features --workspace "$@" -- --show-output

--- a/src/auxiliary.rs
+++ b/src/auxiliary.rs
@@ -53,10 +53,16 @@ pub(super) struct Auxiliary {
     pub(super) active_user_count: AtomicU64,
 
     pub(super) auxiliary_data: SftpAuxiliaryData,
+
+    pub(super) tokio_compat_file_write_limit: usize,
 }
 
 impl Auxiliary {
-    pub(super) fn new(max_pending_requests: u16, auxiliary_data: SftpAuxiliaryData) -> Self {
+    pub(super) fn new(
+        max_pending_requests: u16,
+        auxiliary_data: SftpAuxiliaryData,
+        tokio_compat_file_write_limit: usize,
+    ) -> Self {
         Self {
             conn_info: OnceCell::new(),
 
@@ -75,6 +81,8 @@ impl Auxiliary {
             active_user_count: AtomicU64::new(1),
 
             auxiliary_data,
+
+            tokio_compat_file_write_limit,
         }
     }
 
@@ -149,5 +157,9 @@ impl Auxiliary {
             // self.active_user_count is now equal to 0, ready for shutdown.
             self.order_shutdown()
         }
+    }
+
+    pub(super) fn tokio_compat_file_write_limit(&self) -> usize {
+        self.tokio_compat_file_write_limit
     }
 }

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,9 @@
 #[allow(unused_imports)]
 use crate::*;
 
+/// ## Added
+///  - Add new option [`SftpOptions::tokio_compat_file_write_limit()`] to set write buffer limit
+///    for [`file::TokioCompatFile`].
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -680,7 +680,7 @@ impl AsyncWrite for TokioCompatFile {
         }
 
         if length_changed {
-            let (_, new_bufs, new_buf) = take_io_slices(&bufs, n as usize).unwrap();
+            let (_, new_bufs, new_buf) = take_io_slices(bufs, n as usize).unwrap();
             bufs = new_bufs;
             buf = new_buf;
         }

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -541,7 +541,7 @@ impl AsyncWrite for TokioCompatFile {
 
         let new_write_len = match write_len.checked_add(n as usize) {
             Some(new_write_len) if new_write_len > write_limit => {
-                n = (write_limit - write_len) as u32;
+                n = (write_limit - write_len).try_into().unwrap();
                 write_limit
             }
             None => {
@@ -549,7 +549,7 @@ impl AsyncWrite for TokioCompatFile {
                 // This has to be a separate cases since
                 // write_limit could be set to usize::MAX, in which case
                 // saturating_add would never return anything larger than it.
-                n = (write_limit - write_len) as u32;
+                n = (write_limit - write_len).try_into().unwrap();
                 write_limit
             }
             Some(new_write_len) => new_write_len,
@@ -653,7 +653,7 @@ impl AsyncWrite for TokioCompatFile {
 
         let new_write_len = match write_len.checked_add(n as usize) {
             Some(new_write_len) if new_write_len > write_limit => {
-                n = (write_limit - write_len) as u32;
+                n = (write_limit - write_len).try_into().unwrap();
                 write_limit
             }
             None => {
@@ -661,7 +661,7 @@ impl AsyncWrite for TokioCompatFile {
                 // This has to be a separate cases since
                 // write_limit could be set to usize::MAX, in which case
                 // saturating_add would never return anything larger than it.
-                n = (write_limit - write_len) as u32;
+                n = (write_limit - write_len).try_into().unwrap();
                 write_limit
             }
             Some(new_write_len) => new_write_len,

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -16,7 +16,6 @@ use std::{
     num::{NonZeroU32, NonZeroUsize},
     ops::{Deref, DerefMut},
     pin::Pin,
-    sync::atomic::{AtomicUsize, Ordering},
     task::{Context, Poll},
 };
 
@@ -481,7 +480,8 @@ impl AsyncWrite for TokioCompatFile {
                 ready!(self.as_mut().poll_flush(cx))?;
             }
             None => {
-                // overflow. This has to be a separate cases since
+                // case overflow
+                // This has to be a separate cases since
                 // write_limit could be set to usize::MAX, in which case
                 // saturating_add would never return anything larger
                 // than it.

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -99,7 +99,7 @@ impl TokioCompatFile {
             buffer: BytesMut::new(),
             buffer_len,
 
-            write_len: AtomicUsize::new(0),
+            write_len: 0,
 
             read_future: None,
             write_futures: VecDeque::new(),
@@ -474,7 +474,7 @@ impl AsyncWrite for TokioCompatFile {
             .unwrap_or(max_write_len);
 
         let write_limit = self.get_auxiliary().tokio_compat_file_write_limit();
-        let write_len = self.project().write_len;
+        let write_len = self.as_mut().project().write_len;
         match write_len.checked_add(n as usize) {
             Some(new_write_len) if new_write_len > write_limit => {
                 ready!(self.as_mut().poll_flush(cx))?;

--- a/src/file/tokio_compat_file.rs
+++ b/src/file/tokio_compat_file.rs
@@ -345,6 +345,7 @@ impl TokioCompatFile {
             res
         } else {
             // All futures consumed without error
+            debug_assert_eq!(*this.write_len, 0);
             return Poll::Ready(Ok(()));
         };
 
@@ -602,6 +603,7 @@ impl AsyncWrite for TokioCompatFile {
                 res
             } else {
                 // All futures consumed without error
+                debug_assert_eq!(*this.write_len, 0);
                 break Poll::Ready(Ok(()));
             };
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -122,8 +122,9 @@ impl SftpOptions {
     }
 
     /// Set the write buffer limit for tokio compat file.
-    /// If the write buffer size is larger than the limit in tokio compat file,
-    /// then it will flush one write buffer and following async write operation will be pending.
+    /// If [`crate::file::TokioCompatFile`] has hit the write buffer limit
+    /// set here, then it will flush one write buffer and continue
+    /// sending (part of) the buffer to the server, which could be buffered.
     ///
     /// It is set to usize::MAX by default.
     #[must_use]

--- a/src/options.rs
+++ b/src/options.rs
@@ -123,7 +123,7 @@ impl SftpOptions {
 
     /// Set the write buffer limit for tokio compat file.
     /// If the write buffer size is larger than the limit in tokio compat file,
-    /// then it will flush write buffer one by one until it has available space 
+    /// then it will flush write buffer one by one until it has available space
     /// and following async write operation will be pending.
     ///
     /// It is set to usize::MAX by default.

--- a/src/options.rs
+++ b/src/options.rs
@@ -123,8 +123,8 @@ impl SftpOptions {
 
     /// Set the write buffer limit for tokio compat file.
     /// If the write buffer size is larger than the limit in tokio compat file,
-    /// then the buffer will be flushed and following async write operation will
-    /// be pending until flush operation is completed.
+    /// then it will flush write buffer one by one until it has available space 
+    /// and following async write operation will be pending.
     ///
     /// It is set to usize::MAX by default.
     #[must_use]

--- a/src/options.rs
+++ b/src/options.rs
@@ -133,9 +133,10 @@ impl SftpOptions {
         self
     }
 
-    pub(super) fn get_tokio_compat_file_write_limit(&self) -> NonZeroUsize {
+    pub(super) fn get_tokio_compat_file_write_limit(&self) -> usize {
         self.tokio_compat_file_write_limit
-            .unwrap_or_else(|| NonZeroUsize::new(usize::MAX).unwrap())
+            .map(NonZeroUsize::get)
+            .unwrap_or(usize::MAX)
     }
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -13,6 +13,7 @@ pub struct SftpOptions {
     write_end_buffer_size: Option<NonZeroUsize>,
     flush_interval: Option<Duration>,
     max_pending_requests: Option<NonZeroU16>,
+    tokio_compat_file_write_limit: Option<NonZeroUsize>,
 
     #[cfg(feature = "__ci-tests")]
     max_read_len: Option<NonZeroU32>,
@@ -28,6 +29,7 @@ impl SftpOptions {
             write_end_buffer_size: None,
             flush_interval: None,
             max_pending_requests: None,
+            tokio_compat_file_write_limit: None,
 
             #[cfg(feature = "__ci-tests")]
             max_read_len: None,
@@ -117,6 +119,23 @@ impl SftpOptions {
     pub(super) fn get_read_end_buffer_size(&self) -> NonZeroUsize {
         self.read_end_buffer_size
             .unwrap_or_else(|| NonZeroUsize::new(1024).unwrap())
+    }
+
+    /// Set the write buffer limit for tokio compat file.
+    /// If the write buffer size is larger than the limit in tokio compat file,
+    /// then the buffer will be flushed and following async write operation will
+    /// be pending until flush operation is completed.
+    ///
+    /// It is set to usize::MAX by default.
+    #[must_use]
+    pub const fn tokio_compat_file_write_limit(mut self, limit: NonZeroUsize) -> Self {
+        self.tokio_compat_file_write_limit = Some(limit);
+        self
+    }
+
+    pub(super) fn get_tokio_compat_file_write_limit(&self) -> NonZeroUsize {
+        self.tokio_compat_file_write_limit
+            .unwrap_or_else(|| NonZeroUsize::new(usize::MAX).unwrap())
     }
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -123,8 +123,7 @@ impl SftpOptions {
 
     /// Set the write buffer limit for tokio compat file.
     /// If the write buffer size is larger than the limit in tokio compat file,
-    /// then it will flush write buffer one by one until it has available space
-    /// and following async write operation will be pending.
+    /// then it will flush one write buffer and following async write operation will be pending.
     ///
     /// It is set to usize::MAX by default.
     #[must_use]

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -145,7 +145,7 @@ impl Sftp {
                 write_end_buffer_size.get(),
                 options.get_max_pending_requests(),
                 auxiliary,
-                options.get_tokio_compat_file_write_limit().get(),
+                options.get_tokio_compat_file_write_limit(),
             ))?;
 
             let flush_task = create_flush_task(

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -458,4 +458,9 @@ impl Sftp {
     pub fn max_read_len(&self) -> u32 {
         self.handle.get_auxiliary().limits().read_len
     }
+
+    /// Trigger flush task manually.
+    pub fn manual_flush(&self) {
+        self.handle.get_auxiliary().trigger_flushing()
+    }
 }

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -145,6 +145,7 @@ impl Sftp {
                 write_end_buffer_size.get(),
                 options.get_max_pending_requests(),
                 auxiliary,
+                options.get_tokio_compat_file_write_limit().get(),
             ))?;
 
             let flush_task = create_flush_task(
@@ -169,10 +170,15 @@ impl Sftp {
         write_end_buffer_size: usize,
         max_pending_requests: u16,
         auxiliary: SftpAuxiliaryData,
+        tokio_compat_file_write_limit: usize,
     ) -> Result<WriteEnd, Error> {
         connect(
             MpscQueue::with_capacity(write_end_buffer_size),
-            Auxiliary::new(max_pending_requests, auxiliary),
+            Auxiliary::new(
+                max_pending_requests,
+                auxiliary,
+                tokio_compat_file_write_limit,
+            ),
         )
     }
 

--- a/tests/highlevel.rs
+++ b/tests/highlevel.rs
@@ -690,7 +690,7 @@ async fn sftp_tokio_compact_file_write_buffer_limit() {
     let (mut child, sftp) = connect(option).await;
     let (mut child2, sftp2) = connect(Default::default()).await;
 
-    let content = &content[..min(sftp.max_write_len() as usize, content.len())];
+    let content = &content[..content.len().min(sftp.max_write_len() as usize)];
     assert!(content.len() > 1000 && content.len() < 2000);
 
     let read_entire_file = || async {

--- a/tests/highlevel.rs
+++ b/tests/highlevel.rs
@@ -738,6 +738,7 @@ async fn sftp_tokio_compact_file_write_buffer_limit() {
 
     // close sftp and child
     sftp.close().await.unwrap();
+    sftp2.close().await.unwrap();
     assert!(child.wait().await.unwrap().success());
     assert!(child2.wait().await.unwrap().success());
 }

--- a/tests/highlevel.rs
+++ b/tests/highlevel.rs
@@ -18,10 +18,7 @@ use openssh::{KnownHosts, Session, SessionBuilder};
 use openssh_sftp_client::*;
 use pretty_assertions::assert_eq;
 use sftp_test_common::*;
-use tokio::{
-    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
-    time::sleep,
-};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio_io_utility::write_vectored_all;
 
 async fn connect(options: SftpOptions) -> (process::Child, Sftp) {
@@ -686,7 +683,9 @@ async fn sftp_test_from_sessions() {
 async fn sftp_tokio_compact_file_write_buffer_limit() {
     let path = gen_path("sftp_tokio_compact_file_write_buffer_limit");
     let content = b"HELLO, WORLD!\n".repeat(100);
-    let option = SftpOptions::new().tokio_compat_file_write_limit(NonZeroUsize::new(1000).unwrap());
+    let option = SftpOptions::new()
+        .flush_interval(Duration::from_millis(100))
+        .tokio_compat_file_write_limit(NonZeroUsize::new(1000).unwrap());
 
     let (mut child, sftp) = connect(option).await;
     let (mut child2, sftp2) = connect(Default::default()).await;


### PR DESCRIPTION
Close #89 

~~There is a problem. In added integration test, sftp connection and child process can't close correctly. If we remove the closing code, it can pass the tests.~~

I forget to close the second sftp connection.🤣