### PR TITLE
Fix Drop impl for `TokioCompatFile` & `ReadDir`

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,13 @@
 #[allow(unused_imports)]
 use crate::*;
 
+/// # Fixed
+///
+/// `Drop` implementation to make sure they never panic
+/// if tokio runtime is not avilable.
+///
+///  - [`file::TokioCompatFile::Drop`]
+///  - [`dir::ReadDir::Drop`]
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -18,6 +18,7 @@ use std::{
 
 use futures_core::stream::{FusedStream, Stream};
 use pin_project::{pin_project, pinned_drop};
+use tokio::runtime;
 use tokio_util::sync::WaitForCancellationFutureOwned;
 
 type ResponseFuture = crate::lowlevel::AwaitableNameEntriesFuture<crate::Buffer>;
@@ -194,13 +195,15 @@ impl PinnedDrop for ReadDir {
         let cancellation_fut = dir.0.get_auxiliary().cancel_token.clone().cancelled_owned();
         let do_drop_fut = Self::do_drop(dir, future);
 
-        tokio::spawn(async move {
-            tokio::select! {
-                biased;
+        if let Ok(handle) = runtime::Handle::try_current() {
+            handle.spawn(async move {
+                tokio::select! {
+                    biased;
 
-                _ = cancellation_fut => (),
-                _ = do_drop_fut => (),
-            }
-        });
+                    _ = cancellation_fut => (),
+                    _ = do_drop_fut => (),
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Only spawn future if tokio runtime is available

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>