### PR TITLE
Release openssh-sftp-client v0.13.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh-sftp-client"
-version = "0.13.7"
+version = "0.13.8"
 edition = "2021"
 rust-version = "1.64"
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -5,13 +5,17 @@ use crate::*;
 pub mod unreleased {}
 
 /// # Fixed
+/// `Drop` implementation for `OwnedHandle` to make sure they never panic
+/// if tokio runtime is not avilable.
+pub mod v_0_13_8 {}
+
+/// # Fixed
 ///
 /// `Drop` implementation to make sure they never panic
 /// if tokio runtime is not avilable.
 ///
-///  - [`file::TokioCompatFile::Drop`]
-///  - [`dir::ReadDir::Drop`]
-#[doc(hidden)]
+///  - [`file::TokioCompatFile`]
+///  - [`fs::ReadDir`]
 pub mod v_0_13_7 {}
 
 /// ## Added


### PR DESCRIPTION
I also fix the broken link of v0.13.7 changelog.