### PR TITLE
Set `tokio_compat_file_write_limit` to 640K by default

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use crate::*;
 
+/// # Changed
+///  - Set [`SftpOptions::tokio_compat_file_write_limit`] to 640KB by default.
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -126,7 +126,7 @@ impl SftpOptions {
     /// set here, then it will flush one write buffer and continue
     /// sending (part of) the buffer to the server, which could be buffered.
     ///
-    /// It is set to usize::MAX by default.
+    /// It is set to 640KB (640 * 1024 bytes) by default.
     #[must_use]
     pub const fn tokio_compat_file_write_limit(mut self, limit: NonZeroUsize) -> Self {
         self.tokio_compat_file_write_limit = Some(limit);
@@ -136,7 +136,7 @@ impl SftpOptions {
     pub(super) fn get_tokio_compat_file_write_limit(&self) -> usize {
         self.tokio_compat_file_write_limit
             .map(NonZeroUsize::get)
-            .unwrap_or(usize::MAX)
+            .unwrap_or(640 * 1024)
     }
 }
 


### PR DESCRIPTION
`usize::MAX` is basically no constraint at all and allow `TokioCompatFile` to eat all memory.