### PR TITLE
Support setting time in MetaDataBuilder

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -37,6 +37,12 @@ impl MetaDataBuilder {
         self
     }
 
+    /// Set accessed and modified time of the metadata to be built.
+    pub fn time(&mut self, accessed: UnixTimeStamp, modified: UnixTimeStamp) -> &mut Self {
+        self.0.set_time(accessed.0, modified.0);
+        self
+    }
+
     /// Create a [`MetaData`].
     pub fn create(&self) -> MetaData {
         MetaData::new(self.0)


### PR DESCRIPTION
The time fields (accessed, modified) in MetaData are currently not changeable, but it's supported by the protocol.

Setting time attributes of a file could be useful for many cases, especially to workaround the coarse timestamp granularity (seconds) of sftp. By setting timestamps, we can then tell if a file has been modified within a second.