### PR TITLE
Impl `Default` for `Permissions`

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -337,3 +337,9 @@ impl From<u16> for Permissions {
         result
     }
 }
+
+impl Default for Permissions {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
Improve ergonomics, since there's already a `Permissions::new` function, user expects `Default` to be implemented on `Permission`.