### PR TITLE
chore: Spelling fix for according

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![docs](https://docs.rs/openssh-sftp-client/badge.svg)](https://docs.rs/openssh-sftp-client)
 
-openssh-sftp-client, implements [sftp v3] accodring to
+openssh-sftp-client, implements [sftp v3] according to
 [`openssh-portable/sftp-client.c`] in rust using `tokio` and `serde`.
 
 It exposes highlevel `async` APIs that models closely after `std::fs` that are


### PR DESCRIPTION
According is currently spelled accodring in the README file.

This PR fixes the spelling for the word.