### PR TITLE
fix: hang with buffered I/O

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ scopeguard = "1.1.0"
 openssh = { version = "0.11.0", default-features = false, optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.11.0", features = ["rt", "macros"] }
+tokio = { version = "1.11.0", features = ["rt", "macros", "io-util", "time"] }
 tempfile = "3.1.0"
 pretty_assertions = "1.1.0"
 sftp-test-common = { path = "sftp-test-common" }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -10,7 +10,7 @@ use std::{
 use bytes::Bytes;
 use scopeguard::defer;
 use tokio::{
-    io::{AsyncRead, AsyncWrite},
+    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
     pin,
     sync::oneshot,
     task::{spawn, JoinHandle},
@@ -20,7 +20,7 @@ use tokio_io_utility::{write_all_bytes, ReusableIoSlices};
 
 async fn flush(
     shared_data: &SharedData,
-    writer: Pin<&mut (dyn AsyncWrite + Send)>,
+    mut writer: Pin<&mut (dyn AsyncWrite + Send)>,
     buffer: &mut Vec<Bytes>,
     reusable_io_slices: &mut ReusableIoSlices,
 ) -> Result<(), Error> {
@@ -35,7 +35,13 @@ async fn flush(
     // `Queue` implementation for `MpscQueue` already removes
     // all empty `Bytes`s so that precond of write_all_bytes
     // is satisfied.
-    write_all_bytes(writer, buffer, reusable_io_slices).await?;
+    write_all_bytes(writer.as_mut(), buffer, reusable_io_slices).await?;
+
+    // Flush the writer so that buffered I/O types (e.g. tokio::io::stdout(),
+    // which wraps std::io::Stdout / LineWriter and only flushes on newlines)
+    // actually send the data to the peer. Without this, binary SFTP packets
+    // never reach the sftp-server and the connection hangs.
+    writer.flush().await?;
 
     Ok(())
 }

--- a/tests/buffered_writer.rs
+++ b/tests/buffered_writer.rs
@@ -1,0 +1,37 @@
+/// Regression test for <https://github.com/openssh-rust/openssh-sftp-client/issues/154>
+///
+/// `tokio::io::stdout()` wraps `std::io::Stdout` (`LineWriter<StdoutRaw>`),
+/// which buffers writes and only flushes automatically when it sees `'\n'`.
+/// SFTP is a binary protocol — its packets never contain `'\n'` — so without
+/// an explicit `flush()` call the SSH_FXP_INIT "hello" packet stays in the
+/// buffer and never reaches the sftp-server.  The server never replies with
+/// SSH_FXP_VERSION, and `Sftp::new` hangs forever.
+///
+/// This test reproduces the bug by wrapping the real sftp-server pipe with
+/// `tokio::io::BufWriter`, which has the same buffering semantics as
+/// `tokio::io::stdout()`: `poll_write` accumulates data internally and
+/// `poll_flush` is the only way to push it to the peer.
+use std::time::Duration;
+
+use openssh_sftp_client::{Sftp, SftpOptions};
+use sftp_test_common::launch_sftp;
+
+#[tokio::test]
+async fn sftp_new_works_with_buf_writer() {
+    let (mut child, stdin, stdout) = launch_sftp().await;
+    let buffered_stdin = tokio::io::BufWriter::new(stdin);
+
+    let sftp = tokio::time::timeout(
+        Duration::from_secs(5),
+        Sftp::new(buffered_stdin, stdout, SftpOptions::default()),
+    )
+    .await
+    .expect(
+        "Sftp::new timed out — the SSH_FXP_INIT packet was never flushed \
+         through BufWriter to sftp-server (missing flush() fix?)",
+    )
+    .expect("Sftp::new returned an error");
+
+    sftp.close().await.expect("Sftp::close failed");
+    assert!(child.wait().await.unwrap().success());
+}

--- a/tests/buffered_writer.rs
+++ b/tests/buffered_writer.rs
@@ -7,30 +7,100 @@
 /// buffer and never reaches the sftp-server.  The server never replies with
 /// SSH_FXP_VERSION, and `Sftp::new` hangs forever.
 ///
-/// This test reproduces the bug by wrapping the real sftp-server pipe with
-/// `tokio::io::BufWriter`, which has the same buffering semantics as
-/// `tokio::io::stdout()`: `poll_write` accumulates data internally and
-/// `poll_flush` is the only way to push it to the peer.
+/// This test reproduces the bug with a `HoldWriter` that buffers all writes
+/// indefinitely and only forwards data to the underlying writer on an explicit
+/// `flush()`.  An `Arc<AtomicBool>` records whether `flush` was ever called,
+/// letting the test assert both that `Sftp::new` completes *and* that it did
+/// so by issuing a flush rather than by luck.
+use std::io;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use openssh_sftp_client::{Sftp, SftpOptions};
+use pin_project::pin_project;
 use sftp_test_common::launch_sftp;
+use tokio::io::AsyncWrite;
+
+#[pin_project]
+struct HoldWriter<W> {
+    #[pin]
+    inner: W,
+    buf: Vec<u8>,
+    flushed: Arc<AtomicBool>,
+}
+
+impl<W> HoldWriter<W> {
+    fn new(inner: W, flushed: Arc<AtomicBool>) -> Self {
+        Self {
+            inner,
+            buf: Vec::new(),
+            flushed,
+        }
+    }
+}
+
+impl<W: AsyncWrite> AsyncWrite for HoldWriter<W> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.project().buf.extend_from_slice(buf);
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut this = self.project();
+        while !this.buf.is_empty() {
+            let n = {
+                match this.inner.as_mut().poll_write(cx, &this.buf) {
+                    Poll::Ready(Ok(n)) => n,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Pending => return Poll::Pending,
+                }
+            };
+            this.buf.drain(..n);
+        }
+
+        match this.inner.poll_flush(cx) {
+            Poll::Ready(Ok(())) => {
+                this.flushed.store(true, Ordering::SeqCst);
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().inner.poll_shutdown(cx)
+    }
+}
 
 #[tokio::test]
 async fn sftp_new_works_with_buf_writer() {
     let (mut child, stdin, stdout) = launch_sftp().await;
-    let buffered_stdin = tokio::io::BufWriter::new(stdin);
+
+    let flushed = Arc::new(AtomicBool::new(false));
+    let writer = HoldWriter::new(stdin, flushed.clone());
 
     let sftp = tokio::time::timeout(
         Duration::from_secs(5),
-        Sftp::new(buffered_stdin, stdout, SftpOptions::default()),
+        Sftp::new(writer, stdout, SftpOptions::default()),
     )
     .await
     .expect(
         "Sftp::new timed out — the SSH_FXP_INIT packet was never flushed \
-         through BufWriter to sftp-server (missing flush() fix?)",
+         through HoldWriter to sftp-server (missing flush() fix?)",
     )
     .expect("Sftp::new returned an error");
+
+    assert!(
+        flushed.load(Ordering::SeqCst),
+        "Sftp::new completed but flush() was never called on the writer"
+    );
 
     sftp.close().await.expect("Sftp::close failed");
     assert!(child.wait().await.unwrap().success());


### PR DESCRIPTION
Fix #154

`tokio::io::stdout()` wraps `std::io::Stdout`, which internally is a `LineWriter<StdoutRaw>`. Per the `AsyncWrite` contract, `poll_write` is allowed to buffer data without delivering it to the peer — only `poll_flush` guarantees delivery. `LineWriter` specifically only auto-flushes when it encounters a '\n'. Since SFTP is a binary protocol, its packets never contain '\n'.                                                                                      

The internal flush helper in `src/tasks.rs` called `write_all_bytes` to push the SSH_FXP_INIT "hello" packet into the writer, but never called `writer.flush()` afterward. With a buffered writer the packet stayed trapped in the internal buffer, the sftp-server never received it, never sent SSH_FXP_VERSION in reply, and `Sftp::new` blocked forever waiting for that reply. 

## Performance
For unbuffered writers (pipes, sockets, etc.) `poll_flush` is a no-op, so there is no overhead for the common case.