### PR TITLE
fix: a cancelled connect panics --> shutdown read task instead

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -212,7 +212,9 @@ pub(super) fn create_read_task<R: AsyncRead + Send + 'static>(
         // Receive version and extensions
         let extensions = read_end.as_mut().receive_server_hello_pinned().await?;
 
-        tx.send(extensions).unwrap();
+        if tx.send(extensions).is_err() {
+            return Ok(());
+        }
 
         loop {
             read_end_notify.notified().await;


### PR DESCRIPTION
Just a tiny fix.

**Problem**: `create_read_task` ends the connect path with `tx.send(extensions).unwrap()` (`src/tasks.rs:215`). The receiver lives in the `Sftp::new` future. If a consumer drops the future before the server's `SSH_FXP_VERSION` lands, the send fails, and the `unwrap` panics inside the spawned task.

**Impact**: any consumer code that times out or cancels a connect bumps into this. My app is [Cmdr](https://getcmdr.com), a file manager, and I hit the bug whenever a user closes the sign-in dialog, or when a connect times out on an unreachable host. Both of these drop the future mid-handshake.

The panic shows up as an unrelated task abort, with nothing pointing back at the code that caused it, so it was a bit tricky to find it.

**Repro** (I'm on a `russh` channel, but the transport shouldn't matter):

```rust
let fut = Sftp::new(writer, reader, SftpOptions::new());
let _ = tokio::time::timeout(Duration::from_millis(2), fut).await; // panics in the spawned task
```

**My solution**: I figured, nobody is waiting for the extensions at that point, so a dropped receiver is a normal shutdown. If we return `Ok(())` and let the existing `defer!` order the flush task's shutdown, same as every other exit from this function, that seems correct.

**Workaround**: I found this alternative solution until this PR is merged / the bug is fixed: I run `Sftp::new` in its own task and put the timeout on the `JoinHandle`. Timing out drops the handle, the future still finishes, and its result gets discarded harmlessly.

**Re [#153](https://github.com/openssh-rust/openssh-sftp-client/issues/153)**: I think this is the same bug. That one couldn't be reproed, and I think it's because, as @NobodyXu said: "if sending over oneshot panicks, then the read task would fail and the sftp won't work". Right, but only for a caller who already gave up on that connection, so nobody is around to notice. My repro above is deterministic.